### PR TITLE
Fix soft wrap at wrong column width

### DIFF
--- a/lib/run.coffee
+++ b/lib/run.coffee
@@ -17,10 +17,10 @@ module.exports =
 
           if drawTextLeftAligned is false
             characterWidth = editor.getDefaultCharWidth()
-            charactersPerLine = atom.config.get('editor.preferredLineLength', scope: [currentScope])
+            charactersPerLine = atom.config.get('editor.preferredLineLength')
 
             editor.setSoftWrapped(true)
-            atom.views.getView(editor).style.maxWidth = characterWidth * (charactersPerLine + 4) + 'px'
+            atom.views.getView(editor).style.maxWidth = characterWidth * (charactersPerLine + 6) + 'px'
             atom.views.getView(editor).style.paddingLeft = characterWidth * 2 + 'px'
             atom.views.getView(editor).style.paddingRight = characterWidth * 2 + 'px'
 


### PR DESCRIPTION
This fixes #29 

I'm not entirely sure what was wrong with `charactersPerLine` but it seemed like it was being overwritten by other scopes if typewriter was enabled for all scopes.

I got consistent results in testing with monospace fonts, but variable width fonts are still a gamble and can trail off if the average character width in a line is longer than the value returned by `::getDefaultCharWidth()`. I don't think I'd call it a bug, since the code has never accommodated for that. It's more of a missing feature :smile: 